### PR TITLE
Fixed a bug triggered by running the extractor in a subprocess.

### DIFF
--- a/Extract/ConsoleLogger.cs
+++ b/Extract/ConsoleLogger.cs
@@ -16,7 +16,7 @@ namespace Extract
 			var dir = Path.GetDirectoryName(path);
 			if(dir != "") Directory.CreateDirectory(dir);
 			writer = new StreamWriter(path);
-			if (!RunetimeUtils.IsRunningOnMono)
+			if (!RunetimeUtils.IsRunningOnMono && Console.LargestWindowWidth > 0)
 			{
 				Console.WindowWidth = (int)(Console.LargestWindowWidth * 0.8f);
 				Console.BufferHeight = 2000;


### PR DESCRIPTION
The following exception occurs when I attempt to utilize the Exporter as a subprocess executed by a Ruby script. Since the subprocess does not get a window, setting the window size fails.

```
Unhandled Exception: System.ArgumentOutOfRangeException: Positive number required.
Parameter name: width
Actual value was 0.
   at System.Console.SetWindowSize(Int32 width, Int32 height)
   at Extract.ConsoleLogger..ctor(String path)
   at Extract.Program.Main(String[] args)
```

The change provided by this pull request avoids setting the `Console.WindowWidth` if `Console.LargestWindowWidth` is 0.

P.S. Thanks for this great application! Other applications are either quite outdated, simply broken, or not usable in a CLI setting.